### PR TITLE
Implemented species and species_proteins tables

### DIFF
--- a/backend/init.sql
+++ b/backend/init.sql
@@ -5,18 +5,45 @@
 --      To rerun this file, you'll need to do `sh run.sh reload_init_sql`
 --      Keep in mind this will backup the data to `backend/backups` folder and wipe everything in the docker container DB
 
-
--- TODO: modify for https://lucid.app/lucidchart/4958d57d-101d-4c33-aef3-717c381af45c/edit?invitationId=inv_94f4d938-33ba-4f8d-a758-4ac7f452a594&page=0_0#
--- Note: "Numeric" data types have arbitrary precision which are good for calculations. This seems like what we want.
+-- Note: "Numeric" data types have arbitrary precision which are good for calculations, which seems ideal for this project.
 -- https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL
+
+-- Generated columns:
+-- https://www.postgresql.org/docs/current/ddl-generated-columns.html
+
+/*
+ * Proteins Table
+ */
 CREATE TABLE proteins (
     name text NOT NULL UNIQUE PRIMARY KEY,
-    length integer,
+    length integer, -- 
     mass numeric
 );
 
--- NOTE: These file path links are off-the-cuff, and might not be useful to the frontend, so
--- TODO: Change file path links to something useful
+/*
+ * Species Table
+ */
+CREATE TABLE species (
+    id text NOT NULL UNIQUE PRIMARY KEY, -- This should be the first letters in the scientific name - e.g. "gh", the prefix to the files, for simplicity.
+    tax_genus text NOT NULL,
+    tax_species text NOT NULL,
+    scientific_name text UNIQUE GENERATED ALWAYS AS (tax_genus || ' ' || tax_species) STORED,
+    content bytea
+);
+
+/*
+ * Table: species_proteins
+ * Description: Join table for N:M connection between Species and Proteins
+ */
+ CREATE TABLE species_proteins (
+    species_id text references species(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    protein_id text references proteins(name) ON UPDATE CASCADE ON DELETE CASCADE,
+    PRIMARY KEY (species_id, protein_id)
+ );
+
+/*
+ * Inserts example proteins into proteins table
+ */
 INSERT INTO proteins (name, length, mass) VALUES (
     'Gh_comp271_c0_seq1', 
     0,
@@ -31,3 +58,52 @@ INSERT INTO proteins (name, length, mass) VALUES (
     'Lh14_comp2336_c0_seq1', 
     0,
     0.0);
+
+/*
+ * Inserts example species into species table
+ */
+INSERT INTO species(id, tax_genus, tax_species, content) VALUES (
+    'Gh',
+    'Ganaspis',
+    'hookeri',
+    null
+);
+
+INSERT INTO species(id, tax_genus, tax_species, content) VALUES (
+    'Lb',
+    'Leptopilina',
+    'boulardi',
+    null
+);
+
+INSERT INTO species(id, tax_genus, tax_species, content) VALUES (
+    'Lh',
+    'Leptopilina',
+    'heterotoma',
+    null
+);
+
+ /*
+  * Inserts connections between species and proteins
+  */ 
+INSERT INTO species_proteins(species_id, protein_id) VALUES (
+    'Gh',
+    'Gh_comp271_c0_seq1'
+ );
+
+  /*
+  * Inserts connections between species and proteins
+  */ 
+INSERT INTO species_proteins(species_id, protein_id) VALUES (
+    'Lb',
+    'Lb17_comp535_c2_seq1'
+ );
+
+ /*
+  * Inserts connections between species and proteins
+  */ 
+INSERT INTO species_proteins(species_id, protein_id) VALUES (
+    'Lh',
+    'Lh14_comp2336_c0_seq1'
+ );
+


### PR DESCRIPTION
Feature: Species Table

The species table has the following attributes:
- id: This should be the initials of the scientific name, e.g. "gh". This convention only works because the lab is working with three species, but if this were to ever support a lot more species, we would have to choose a more unique primary key system.
- tax_genus: The taxonomic genus name for this species. I created separate attributes for "species" and "genus" because that may make it easier to make certain API calls in the future (e.g. https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?name=Leptopilina+boulardi)
- tax_species: The taxonomic species name for this species. See above.
- scientific_name: The full scientific name for the species. This is autogenerated from tax_genus and tax_species.

Feature: Species_Proteins Table

The species protein table is a join table to represent a many-to-many connection between species and proteins. Currently, I don't think any protein in the Galaxy folder actually belongs to more than one species - However, it's _technically possible_ for a protein to belong to more than one species, so it's likely in our best interest to implement it this way.