### PR TITLE
feat: store markdown for each protein entry

### DIFF
--- a/backend/init.sql
+++ b/backend/init.sql
@@ -45,20 +45,26 @@ CREATE TABLE species (
 /*
  * Inserts example proteins into proteins table
  */
-INSERT INTO proteins (name, length, mass) VALUES (
+INSERT INTO proteins (name, length, mass, content) VALUES (
     'Gh_comp271_c0_seq1', 
     0,
-    0.0);
+    0.0,
+    null
+);
 
-INSERT INTO proteins (name, length, mass) VALUES (
+INSERT INTO proteins (name, length, mass, content) VALUES (
     'Lb17_comp535_c2_seq1', 
     0,
-    0.0);
+    0.0,
+    null
+);
 
-INSERT INTO proteins (name, length, mass) VALUES (
+INSERT INTO proteins (name, length, mass, content) VALUES (
     'Lh14_comp2336_c0_seq1', 
     0,
-    0.0);
+    0.0,
+    null
+);
 
 /*
  * Inserts example species into species table

--- a/backend/init.sql
+++ b/backend/init.sql
@@ -15,9 +15,10 @@
  * Proteins Table
  */
 CREATE TABLE proteins (
-    name text NOT NULL UNIQUE PRIMARY KEY,
-    length integer, -- 
-    mass numeric
+    name text NOT NULL UNIQUE PRIMARY KEY, -- user specified name of the protein (TODO: consider having a string limit)
+    length integer, -- length of amino acid sequence
+    mass numeric, -- mass in amu/daltons
+    content bytea -- stored markdown for the protein article (TODO: consider having a limit to how big this can be)
 );
 
 /*

--- a/backend/src/api_types.py
+++ b/backend/src/api_types.py
@@ -27,6 +27,7 @@ class ProteinEntry(CamelModel):
     name: str
     length: int
     mass: float
+    content: str = ""
 
 
 class AllEntries(CamelModel):

--- a/backend/src/api_types.py
+++ b/backend/src/api_types.py
@@ -27,7 +27,7 @@ class ProteinEntry(CamelModel):
     name: str
     length: int
     mass: float
-    content: str = ""
+    content: str | None = None
 
 
 class AllEntries(CamelModel):

--- a/backend/src/api_types.py
+++ b/backend/src/api_types.py
@@ -35,6 +35,7 @@ class AllEntries(CamelModel):
 
 class UploadBody(CamelModel):
     name: str
+    content: str  # markdown content from user
     pdb_file_base64: str
 
 

--- a/backend/src/db.py
+++ b/backend/src/db.py
@@ -60,3 +60,7 @@ class Database:
 
     def __exit__(self, type, value, traceback):
         self.disconnect()
+
+
+def str_to_bytea(_str: str):
+    return psycopg.Binary(_str.encode("utf-8"))

--- a/backend/src/db.py
+++ b/backend/src/db.py
@@ -64,3 +64,7 @@ class Database:
 
 def str_to_bytea(_str: str):
     return psycopg.Binary(_str.encode("utf-8"))
+
+
+def bytea_to_str(_bytea):
+    return _bytea.decode("utf-8")

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -1,6 +1,6 @@
 from .setup import init_fastapi_app, disable_cors
 from .api_types import ProteinEntry, UploadBody, UploadError
-from .db import Database
+from .db import Database, str_to_bytea
 from .protein import Protein
 import logging as log
 from fastapi.staticfiles import StaticFiles
@@ -71,13 +71,27 @@ def upload_protein_entry(body: UploadBody):
 
     # if name is unique, save the pdb file and add the entry to the database
     try:
+        # TODO: consider somehow sending the file as a stream instead of a b6 string or send as regular string
         pdb = Protein.parse_pdb(body.name, body.pdb_file_base64, encoding="b64")
     except Exception:
         return UploadError.PARSE_ERROR
 
-    # Save to data/ folder and db
     try:
-        Protein.save(pdb)
+        # write to file to data/ folder
+        with open(pdb.pdb_file_name, "w") as f:
+            f.write(pdb.file_contents)
+
+        # save to db
+        with Database() as db:
+            db.execute(
+                """INSERT INTO proteins (name, length, mass, content) VALUES (%s, %s, %s, %s);""",
+                [
+                    pdb.name,
+                    pdb.num_amino_acids,
+                    pdb.mass_daltons,
+                    str_to_bytea(body.content),
+                ],
+            )
     except Exception:
         return UploadError.WRITE_ERROR
 

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -77,7 +77,7 @@ def upload_protein_entry(body: UploadBody):
 
     # if name is unique, save the pdb file and add the entry to the database
     try:
-        # TODO: consider somehow sending the file as a stream instead of a b6 string or send as regular string
+        # TODO: consider somehow sending the file as a stream instead of a b64 string or send as regular string
         pdb = Protein.parse_pdb(body.name, body.pdb_file_base64, encoding="b64")
     except Exception:
         return UploadError.PARSE_ERROR

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -1,6 +1,6 @@
 from .setup import init_fastapi_app, disable_cors
 from .api_types import ProteinEntry, UploadBody, UploadError
-from .db import Database, str_to_bytea
+from .db import Database, str_to_bytea, bytea_to_str
 from .protein import Protein
 import logging as log
 from fastapi.staticfiles import StaticFiles
@@ -53,8 +53,10 @@ def get_protein_entry(protein_name: str):
             if entry_sql is not None and len(entry_sql) != 0:
                 # return the only entry
                 only_returned_entry = entry_sql[0]
-                name, length, mass, content_bytea = only_returned_entry
-                content = content_bytea.decode("utf-8")  # convert bytes to string
+                name, length, mass, content = only_returned_entry
+                # if bytes are present, decode them into a string
+                if content is not None:
+                    content = bytea_to_str(content)
 
                 return ProteinEntry(
                     name=name, length=length, mass=mass, content=content

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -43,7 +43,7 @@ def get_protein_entry(protein_name: str):
     with Database() as db:
         try:
             entry_sql = db.execute_return(
-                """SELECT name, length, mass FROM proteins
+                """SELECT name, length, mass, content FROM proteins
                     WHERE name = %s""",
                 [protein_name],
             )
@@ -53,8 +53,12 @@ def get_protein_entry(protein_name: str):
             if entry_sql is not None and len(entry_sql) != 0:
                 # return the only entry
                 only_returned_entry = entry_sql[0]
-                name, length, mass = only_returned_entry
-                return ProteinEntry(name=name, length=length, mass=mass)
+                name, length, mass, content_bytea = only_returned_entry
+                content = content_bytea.decode("utf-8")  # convert bytes to string
+
+                return ProteinEntry(
+                    name=name, length=length, mass=mass, content=content
+                )
 
         except Exception as e:
             log.error(e)

--- a/frontend/src/openapi/models/ProteinEntry.ts
+++ b/frontend/src/openapi/models/ProteinEntry.ts
@@ -7,5 +7,6 @@ export type ProteinEntry = {
     name: string;
     length: number;
     mass: number;
+    content?: (string | null);
 };
 

--- a/frontend/src/openapi/models/UploadBody.ts
+++ b/frontend/src/openapi/models/UploadBody.ts
@@ -5,6 +5,7 @@
 
 export type UploadBody = {
     name: string;
+    content: string;
     pdbFileBase64: string;
 };
 

--- a/frontend/src/routes/protein/[proteinName]/+page.svelte
+++ b/frontend/src/routes/protein/[proteinName]/+page.svelte
@@ -10,22 +10,6 @@
 	export let data; // linked to +page.ts return (aka the id)
 	let entry: ProteinEntry | null = null;
 	let error = false;
-	// todo: request this from the user
-	let wikiEntry: string = `
-# H1
-
-## H2
-
-### H3
-
-#### H4
-
-**Bolded** versus _italic_
-and ~~strike through~~ and [links](/)
-
-You can write stuff down here about the proteins.
-
-Todo: add ways to cite papers here that automatically show up in references.`;
 
 	// when this component mounts, request protein wikipedia entry from backend
 	onMount(async () => {
@@ -92,7 +76,11 @@ Todo: add ways to cite papers here that automatically show up in references.`;
 			<!-- Article / Wiki entry -->
 			<Card title="Info" class="max-w-full mt-5">
 				<Heading tag="h4">Article</Heading>
-				<Markdown text={wikiEntry} />
+				{#if entry.content != null}
+					<Markdown text={entry.content} />
+				{:else}
+					No article added
+				{/if}
 			</Card>
 		</div>
 		<div id="right-side">

--- a/frontend/src/routes/protein/[proteinName]/+page.svelte
+++ b/frontend/src/routes/protein/[proteinName]/+page.svelte
@@ -76,7 +76,7 @@
 			<!-- Article / Wiki entry -->
 			<Card title="Info" class="max-w-full mt-5">
 				<Heading tag="h4">Article</Heading>
-				{#if entry.content != null}
+				{#if entry.content !== null}
 					<Markdown text={entry.content} />
 				{:else}
 					No article added

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -1,13 +1,22 @@
 <script lang="ts">
 	import { Backend, UploadError } from "$lib/backend";
-	import { Fileupload, Button, Input, Label, Helper } from "flowbite-svelte";
+	import {
+		Fileupload,
+		Button,
+		Input,
+		Label,
+		Helper,
+		Textarea,
+	} from "flowbite-svelte";
 	import { goto } from "$app/navigation";
 	import { formatProteinName } from "$lib/format";
 
 	let name: string = "";
+	let content: string = "";
 	let files: FileList | undefined; // bind:files on the Fileupload
 	let uploadError: UploadError | undefined;
 	$: file = files ? files[0] : undefined; // we're just concerned with one file
+	$: console.log(content);
 
 	function fileToBase64(f: File): Promise<string> {
 		return new Promise((resolve, reject) => {
@@ -43,6 +52,15 @@
 			{/if}
 		</div>
 		<div>
+			<Label for="content" class="block mb-2">Protein Article</Label>
+			<Textarea
+				id="content"
+				placeholder="Enter markdown..."
+				rows={10}
+				bind:value={content}
+			/>
+		</div>
+		<div>
 			<Fileupload class="w-100" bind:files />
 		</div>
 		<div>
@@ -55,6 +73,7 @@
 						const err = await Backend.uploadProteinEntry({
 							name,
 							pdbFileBase64: base64Encoding,
+							content,
 						});
 						if (err) {
 							uploadError = err;


### PR DESCRIPTION
https://github.com/xnought/venome/assets/65095341/97583d99-b3a8-4b0d-8fbe-882c5a9926ce

References issue #69, very nice

- [x] change schema to add content blob
- [x] add textbox in frontend upload page
- [x] create backend endpoint to store the markdown
- [x] call the function from the frontend to store
- [x] modify the all_entries and get_entry to also send content

## Changes to know about

- the `init.sql` now has a content column in proteins as a bytea
- the backend endpoints in `server.py` now can now take content and store it as well as return it to the user