### PR TITLE
feat: put the frontend outside of docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,19 @@
 # https://github.com/zeno-ml/zeno-hub/blob/main/docker-compose.yml
 version: "3"
 services:
-    frontend:
-        container_name: venome-frontend
-        build:
-            context: ./frontend
-            dockerfile: Dockerfile
-        volumes:
-            - ./frontend:/app
-            - docker_node_modules:/app/node_modules/
-        ports:
-            - "5173:5173"
-        environment:
-            PUBLIC_BACKEND_URL: http://localhost:8000
-        command: ["yarn", "dev", "--", "--host", "0.0.0.0"]
+    # frontend:
+    #     container_name: venome-frontend
+    #     build:
+    #         context: ./frontend
+    #         dockerfile: Dockerfile
+    #     volumes:
+    #         - ./frontend:/app
+    #         - docker_node_modules:/app/node_modules/
+    #     ports:
+    #         - "5173:5173"
+    #     environment:
+    #         PUBLIC_BACKEND_URL: http://localhost:8000
+    #     command: ["yarn", "dev", "--", "--host", "0.0.0.0"]
     backend:
         container_name: venome-backend
         build:
@@ -55,5 +55,5 @@ services:
 
 volumes:
     postgres_data:
-    docker_node_modules:
+    # docker_node_modules:
     docker_venv:

--- a/frontend/src/lib/backend.ts
+++ b/frontend/src/lib/backend.ts
@@ -3,6 +3,7 @@ export { DefaultService as Backend } from "../openapi";
 import { OpenAPI } from "../openapi";
 import { env } from "$env/dynamic/public";
 
-export const BACKEND_URL = env["PUBLIC_BACKEND_URL"];
+// export const BACKEND_URL = env["PUBLIC_BACKEND_URL"];
+export const BACKEND_URL = "http://localhost:8000";
 if (!BACKEND_URL) throw new Error("PUBLIC_BACKEND_URL is not set in .env");
 OpenAPI.BASE = BACKEND_URL;


### PR DESCRIPTION
**Draft work in progress, don't merge yet**

**Please let me know if this new method is faster (moving the frontend out of the docker container)**

https://github.com/xnought/venome/assets/65095341/0f7e7a2a-fb7e-49b4-a863-9e73c36e8d8f

Watch the video where I go through the following steps:

All I do is 

Go to this branch
```bash
git checkout faster
```

hard restart
```bash
./run.sh hard_restart
```

run the frontend not in the docker
```bash
cd frontend
yarn install
yarn dev --open
```

upload all the proteins to test stuff out
```bash
cd .. # go back to project root
./run.sh upload_all 
```

Go to `http://localhost:5173`