### PR TITLE
Added API Token Verification to lock restricted calls

### DIFF
--- a/backend/src/api/protein.py
+++ b/backend/src/api/protein.py
@@ -182,7 +182,6 @@ def get_protein_entry(protein_name: str):
 # TODO: add permissions so only the creator can delete not just anyone
 @router.delete("/protein/entry/{protein_name:str}", response_model=None)
 def delete_protein_entry(protein_name: str, req: Request):
-    print("DELETING")
     requiresAuthentication(req)
     # Todo, have a meaningful error if the delete fails
     with Database() as db:

--- a/backend/src/api/protein.py
+++ b/backend/src/api/protein.py
@@ -7,9 +7,11 @@ from Bio.SeqUtils import molecular_weight, seq1
 from ..db import Database, bytea_to_str, str_to_bytea
 
 from ..api_types import ProteinEntry, UploadBody, UploadError, EditBody, CamelModel
+from ..auth import requiresAuthentication
 from io import BytesIO
 from fastapi import APIRouter
 from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.requests import Request
 
 router = APIRouter()
 
@@ -179,7 +181,9 @@ def get_protein_entry(protein_name: str):
 
 # TODO: add permissions so only the creator can delete not just anyone
 @router.delete("/protein/entry/{protein_name:str}", response_model=None)
-def delete_protein_entry(protein_name: str):
+def delete_protein_entry(protein_name: str, req: Request):
+    print("DELETING")
+    requiresAuthentication(req)
     # Todo, have a meaningful error if the delete fails
     with Database() as db:
         # remove protein
@@ -207,7 +211,8 @@ def upload_protein_png(body: UploadPNGBody):
 
 # None return means success
 @router.post("/protein/upload", response_model=UploadError | None)
-def upload_protein_entry(body: UploadBody):
+def upload_protein_entry(body: UploadBody, req: Request):
+    requiresAuthentication(req)
     # check that the name is not already taken in the DB
     if protein_name_found(body.name):
         return UploadError.NAME_NOT_UNIQUE
@@ -262,10 +267,10 @@ def upload_protein_entry(body: UploadBody):
 
 # TODO: add more edits, now only does name and content edits
 @router.put("/protein/edit", response_model=UploadError | None)
-def edit_protein_entry(body: EditBody):
+def edit_protein_entry(body: EditBody, req: Request):
     # check that the name is not already taken in the DB
     # TODO: check if permission so we don't have people overriding other people's names
-
+    requiresAuthentication(req)
     try:
         if body.new_name != body.old_name:
             os.rename(pdb_file_name(body.old_name), pdb_file_name(body.new_name))

--- a/backend/src/auth.py
+++ b/backend/src/auth.py
@@ -37,11 +37,8 @@ def authenticateToken(token):
 # Use this function with a request if you want.
 def requiresAuthentication(req: Request):
     userInfo = authenticateToken(req.headers["authorization"])
-    if (not userInfo or not userInfo.get("admin")):
+    if not userInfo or not userInfo.get("admin"):
         print("Unauthorized User")
-        raise HTTPException(
-            status_code=403,
-            detail="Unauthorized"
-        )
+        raise HTTPException(status_code=403, detail="Unauthorized")
     else:
         print("User authorized.")

--- a/backend/src/auth.py
+++ b/backend/src/auth.py
@@ -2,6 +2,7 @@ import jwt
 from datetime import datetime, timezone, timedelta
 from fastapi.requests import Request
 from fastapi import HTTPException
+import logging as log
 
 # TODO: This method of secret key generation is, obviously, extremely unsafe.
 # This needs to be changed.
@@ -22,15 +23,15 @@ def authenticateToken(token):
     try:
         # Valid token is always is in the form "Bearer [token]", so we need to slice off the "Bearer" portion.
         sliced_token = token[7:]
-        print(sliced_token)
+        log.warn(sliced_token)
         decoded = jwt.decode(sliced_token, secret_key, algorithms="HS256")
-        print("Valid token")
-        print(decoded)
+        log.warn("Valid token")
+        log.warn(decoded)
         return decoded
 
     # If the token is invalid, return None.
     except Exception as err:
-        print("Invalid token:", err)
+        log.error("Invalid token:", err)
         return None
 
 
@@ -38,7 +39,7 @@ def authenticateToken(token):
 def requiresAuthentication(req: Request):
     userInfo = authenticateToken(req.headers["authorization"])
     if not userInfo or not userInfo.get("admin"):
-        print("Unauthorized User")
+        log.error("Unauthorized User")
         raise HTTPException(status_code=403, detail="Unauthorized")
     else:
-        print("User authorized.")
+        log.warn("User authorized.")

--- a/backend/src/auth.py
+++ b/backend/src/auth.py
@@ -1,5 +1,7 @@
 import jwt
 from datetime import datetime, timezone, timedelta
+from fastapi.requests import Request
+from fastapi import HTTPException
 
 # TODO: This method of secret key generation is, obviously, extremely unsafe.
 # This needs to be changed.
@@ -15,13 +17,31 @@ def generateAuthToken(userId, admin):
     return jwt.encode(payload, secret_key, algorithm="HS256")
 
 
-# TODO: Find out how FastAPI handles middleware functions, and turn this into one.
 def authenticateToken(token):
     # Return the decoded token if it's valid.
     try:
-        decoded = jwt.decode(token, secret_key, algorithms="HS256")
+        # Valid token is always is in the form "Bearer [token]", so we need to slice off the "Bearer" portion.
+        sliced_token = token[7:]
+        print(sliced_token)
+        decoded = jwt.decode(sliced_token, secret_key, algorithms="HS256")
+        print("Valid token")
+        print(decoded)
         return decoded
 
     # If the token is invalid, return None.
-    except Exception:
+    except Exception as err:
+        print("Invalid token:", err)
         return None
+
+
+# Use this function with a request if you want.
+def requiresAuthentication(req: Request):
+    userInfo = authenticateToken(req.headers["authorization"])
+    if (not userInfo or not userInfo.get("admin")):
+        print("Unauthorized User")
+        raise HTTPException(
+            status_code=403,
+            detail="Unauthorized"
+        )
+    else:
+        print("User authorized.")

--- a/frontend/src/lib/backend.ts
+++ b/frontend/src/lib/backend.ts
@@ -1,6 +1,19 @@
 export * from "./openapi";
 export { DefaultService as Backend } from "./openapi";
 import { OpenAPI } from "./openapi";
+import Cookies from "js-cookie";
 
 export const BACKEND_URL = "http://localhost:8000";
 OpenAPI.BASE = BACKEND_URL;
+
+// Sets the token header to the stored authentication token from the cookie
+export function setToken() {
+	console.log("Setting Token")
+	OpenAPI.TOKEN = Cookies.get("auth")
+}
+
+// Sets the token header to nothing.
+export function clearToken() {
+	console.log("Clearing token.")
+	OpenAPI.TOKEN = undefined
+}

--- a/frontend/src/routes/Edit.svelte
+++ b/frontend/src/routes/Edit.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Backend, UploadError, type ProteinEntry } from "../lib/backend";
+	import { Backend, UploadError, setToken, type ProteinEntry } from "../lib/backend";
 	import { Button, Input, Label, Helper, Select } from "flowbite-svelte";
 	import { navigate } from "svelte-routing";
 	import { onMount } from "svelte";
@@ -140,6 +140,7 @@
 					on:click={async () => {
 						if (entry) {
 							try {
+								setToken()
 								const err = await Backend.editProteinEntry({
 									newName: name,
 									oldName: entry.name,
@@ -179,6 +180,7 @@
 				<Button
 					color="red"
 					on:click={async () => {
+						setToken()
 						await Backend.deleteProteinEntry(urlId);
 						navigate("/");
 					}}>Delete Protein Entry</Button

--- a/frontend/src/routes/Login.svelte
+++ b/frontend/src/routes/Login.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Backend, type LoginResponse } from "../lib/backend";
+	import { Backend, clearToken, type LoginResponse } from "../lib/backend";
 	import { Button, Label, Input } from "flowbite-svelte";
 	import Cookies from "js-cookie";
 	import { onMount } from "svelte";
@@ -11,6 +11,7 @@
 	 * We want to do this to avoid bugs, and to let the user log out.
 	 */
 	 onMount(async () => {
+		clearToken()
 		Cookies.remove("auth")
 		$user.loggedIn = false
 		$user.username = ""

--- a/frontend/src/routes/Upload.svelte
+++ b/frontend/src/routes/Upload.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Backend, UploadError } from "../lib/backend";
+	import { Backend, UploadError, setToken } from "../lib/backend";
 	import {
 		Fileupload,
 		Button,
@@ -108,6 +108,7 @@
 
 					const pdbFileStr = await fileToString(file);
 					try {
+						setToken()
 						const err = await Backend.uploadProteinEntry({
 							name,
 							description,


### PR DESCRIPTION
https://github.com/xnought/venome/assets/45224464/456b2039-1e84-4121-a81f-5adb2441367e



I implemented basic token sending and validation between the frontend and the backend. To do this, I implemented two simple 
functions:

1. Frontend: setToken(). This function automatically looks at the authentication cookie, and sets the OpenAPI authorization header to the bearer token stored in that cookie. Meant to be placed right before making a restricted call (e.g. inside of a button's onSubmit).

2. Backend: requireAuthentication(req). This takes in a FastAPI Request object and validates the token header in that object, and ensures that the user giving the token is an admin. Automatically returns 403 Forbidden if the token is invalid or the user is not an admin. Meant to be placed at the top of any restricted API request.

The API calls being locked right now are protein edit, upload, and delete.

The changes present here are not user-facing, so the only real way to test it is to do the above commands and see if they break or not. I also included some print commands which you can see in the backend's log in Docker.. These changes should, in the future, be more extensively-changed

Closes #175 
Closes #131 
Closes #132 
Closes #133 