### PR TITLE
Protein Search Paging

### DIFF
--- a/backend/src/api/search.py
+++ b/backend/src/api/search.py
@@ -96,7 +96,7 @@ def gen_sql_filters(
 @router.post("/search/proteins", response_model=SearchProteinsResults)
 def search_proteins(body: SearchProteinsBody):
     text_query = sanitize_query(body.query)
-    limit = 10000 # Limit defaulted to exceed the number of entries in db to grab whole thing.
+    limit = 10000  # Limit defaulted to exceed the number of entries in db to grab whole thing.
     offset = 0
     with Database() as db:
         try:
@@ -105,7 +105,7 @@ def search_proteins(body: SearchProteinsBody):
             if body.proteinsPerPage != None and body.page != None:
                 limit = body.proteinsPerPage
                 offset = limit * body.page
-                
+
             filter_clauses = gen_sql_filters(
                 "species",
                 "proteins_scores",

--- a/backend/src/api/search.py
+++ b/backend/src/api/search.py
@@ -29,7 +29,7 @@ class SearchProteinsBody(CamelModel):
     species_filter: str | None = None
     length_filter: RangeFilter | None = None
     mass_filter: RangeFilter | None = None
-    num: int | None = None
+    proteinsPerPage: int | None = None
     page: int | None = None
 
 
@@ -102,8 +102,8 @@ def search_proteins(body: SearchProteinsBody):
         try:
             # If both the number requested and the page number are present in the request, the limit and offset are set.
             # Otherwise, defaults to entire database.
-            if body.num != None and body.page != None:
-                limit = body.num
+            if body.proteinsPerPage != None and body.page != None:
+                limit = body.proteinsPerPage
                 offset = limit * body.page
                 
             filter_clauses = gen_sql_filters(
@@ -135,7 +135,8 @@ def search_proteins(body: SearchProteinsBody):
                                 JOIN species ON species.id = proteins_scores.species_id
                                 WHERE {} {}
                                 ORDER BY (proteins_scores.name_score*4 + proteins_scores.desc_score*2 + proteins_scores.content_score) DESC
-                                LIMIT {} OFFSET {};
+                                LIMIT {}
+                                OFFSET {};
                                 """.format(
                 score_filter, filter_clauses, limit, offset
             )  # numbers in order by correspond to weighting

--- a/backend/src/api/search.py
+++ b/backend/src/api/search.py
@@ -102,7 +102,7 @@ def search_proteins(body: SearchProteinsBody):
         try:
             # If both the number requested and the page number are present in the request, the limit and offset are set.
             # Otherwise, defaults to entire database.
-            if body.proteinsPerPage != None and body.page != None:
+            if body.proteinsPerPage is not None and body.page is not None:
                 limit = body.proteinsPerPage
                 offset = limit * body.page
 

--- a/frontend/src/lib/openapi/core/ApiError.ts
+++ b/frontend/src/lib/openapi/core/ApiError.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/core/ApiRequestOptions.ts
+++ b/frontend/src/lib/openapi/core/ApiRequestOptions.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/core/ApiResult.ts
+++ b/frontend/src/lib/openapi/core/ApiResult.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/core/CancelablePromise.ts
+++ b/frontend/src/lib/openapi/core/CancelablePromise.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
@@ -85,9 +85,9 @@ export class CancelablePromise<T> implements Promise<T> {
         });
     }
 
-     get [Symbol.toStringTag]() {
-            return "Cancellable Promise";
-     }
+    get [Symbol.toStringTag]() {
+        return "Cancellable Promise";
+    }
 
     public then<TResult1 = T, TResult2 = never>(
         onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,

--- a/frontend/src/lib/openapi/core/OpenAPI.ts
+++ b/frontend/src/lib/openapi/core/OpenAPI.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/core/request.ts
+++ b/frontend/src/lib/openapi/core/request.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
@@ -164,7 +164,7 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
         headers['Authorization'] = `Basic ${credentials}`;
     }
 
-    if (options.body) {
+    if (options.body !== undefined) {
         if (options.mediaType) {
             headers['Content-Type'] = options.mediaType;
         } else if (isBlob(options.body)) {

--- a/frontend/src/lib/openapi/index.ts
+++ b/frontend/src/lib/openapi/index.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/Article.ts
+++ b/frontend/src/lib/openapi/models/Article.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/ArticleImageComponent.ts
+++ b/frontend/src/lib/openapi/models/ArticleImageComponent.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/ArticleProteinComponent.ts
+++ b/frontend/src/lib/openapi/models/ArticleProteinComponent.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/ArticleTextComponent.ts
+++ b/frontend/src/lib/openapi/models/ArticleTextComponent.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/ArticleUpload.ts
+++ b/frontend/src/lib/openapi/models/ArticleUpload.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/EditArticleImageComponent.ts
+++ b/frontend/src/lib/openapi/models/EditArticleImageComponent.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/EditArticleMetadata.ts
+++ b/frontend/src/lib/openapi/models/EditArticleMetadata.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/EditArticleProteinComponent.ts
+++ b/frontend/src/lib/openapi/models/EditArticleProteinComponent.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/EditArticleTextComponent.ts
+++ b/frontend/src/lib/openapi/models/EditArticleTextComponent.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/EditBody.ts
+++ b/frontend/src/lib/openapi/models/EditBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/HTTPValidationError.ts
+++ b/frontend/src/lib/openapi/models/HTTPValidationError.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/InsertBlankComponentEnd.ts
+++ b/frontend/src/lib/openapi/models/InsertBlankComponentEnd.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/InsertComponent.ts
+++ b/frontend/src/lib/openapi/models/InsertComponent.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/LoginBody.ts
+++ b/frontend/src/lib/openapi/models/LoginBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/LoginResponse.ts
+++ b/frontend/src/lib/openapi/models/LoginResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/MoveComponent.ts
+++ b/frontend/src/lib/openapi/models/MoveComponent.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/ProteinEditSuccess.ts
+++ b/frontend/src/lib/openapi/models/ProteinEditSuccess.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/ProteinEntry.ts
+++ b/frontend/src/lib/openapi/models/ProteinEntry.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/RangeFilter.ts
+++ b/frontend/src/lib/openapi/models/RangeFilter.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/SearchProteinsBody.ts
+++ b/frontend/src/lib/openapi/models/SearchProteinsBody.ts
@@ -8,7 +8,7 @@ export type SearchProteinsBody = {
     speciesFilter?: (string | null);
     lengthFilter?: (RangeFilter | null);
     massFilter?: (RangeFilter | null);
-    num?: (number | null);
+    proteinsPerPage?: (number | null);
     page?: (number | null);
 };
 

--- a/frontend/src/lib/openapi/models/SearchProteinsBody.ts
+++ b/frontend/src/lib/openapi/models/SearchProteinsBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
@@ -8,5 +8,7 @@ export type SearchProteinsBody = {
     speciesFilter?: (string | null);
     lengthFilter?: (RangeFilter | null);
     massFilter?: (RangeFilter | null);
+    num?: (number | null);
+    page?: (number | null);
 };
 

--- a/frontend/src/lib/openapi/models/SearchProteinsResults.ts
+++ b/frontend/src/lib/openapi/models/SearchProteinsResults.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/SimilarProtein.ts
+++ b/frontend/src/lib/openapi/models/SimilarProtein.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/UploadArticleImageComponent.ts
+++ b/frontend/src/lib/openapi/models/UploadArticleImageComponent.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/UploadArticleProteinComponent.ts
+++ b/frontend/src/lib/openapi/models/UploadArticleProteinComponent.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/UploadArticleTextComponent.ts
+++ b/frontend/src/lib/openapi/models/UploadArticleTextComponent.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/UploadBody.ts
+++ b/frontend/src/lib/openapi/models/UploadBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/UploadError.ts
+++ b/frontend/src/lib/openapi/models/UploadError.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/UploadPNGBody.ts
+++ b/frontend/src/lib/openapi/models/UploadPNGBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/models/ValidationError.ts
+++ b/frontend/src/lib/openapi/models/ValidationError.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/lib/openapi/services/DefaultService.ts
+++ b/frontend/src/lib/openapi/services/DefaultService.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/frontend/src/routes/Search.svelte
+++ b/frontend/src/routes/Search.svelte
@@ -145,7 +145,12 @@
 		</form>
 		{#if totalFound > 0}
 			<div id="found">
-				{totalFound} proteins shown |
+                {#if totalFound == 1}
+                    {totalFound} protein shown |
+                {:else}
+                    {totalFound} proteins shown |
+                {/if}
+				
                 <Button disabled={page <= 0} on:click={async()=>{
                     page--
                     await search();

--- a/frontend/src/routes/Search.svelte
+++ b/frontend/src/routes/Search.svelte
@@ -6,6 +6,7 @@
 	import { Search, Button } from "flowbite-svelte";
 	import RangerFilter from "../lib/RangerFilter.svelte";
 	import DelayedSpinner from "../lib/DelayedSpinner.svelte";
+    import app from "../main";
 
 	let query = "";
 	let proteinEntries: ProteinEntry[];

--- a/frontend/src/routes/Search.svelte
+++ b/frontend/src/routes/Search.svelte
@@ -156,11 +156,13 @@
                 }}>Next {proteinsPerPage}</Button>
 			</div>
 		{/if}
-		{#if proteinEntries === undefined || proteinEntries.length === 0}
+		{#if proteinEntries === undefined}
 			<DelayedSpinner
 				text="Fetching Proteins from the Venome DB..."
 				textRight
 			/>
+        {:else if proteinEntries.length === 0}
+            No proteins found
 		{:else}
 			<ListProteins allEntries={proteinEntries} />
 		{/if}

--- a/frontend/src/routes/Search.svelte
+++ b/frontend/src/routes/Search.svelte
@@ -53,6 +53,10 @@
 		proteinEntries = result.proteinEntries;
 		totalFound = result.totalFound;
 	}
+    async function searchAndResetPage() {
+        page = 0;
+        await search();
+    }
 	async function resetFilter() {
 		speciesFilter = undefined;
 		lengthFilter = lengthExtent;
@@ -133,7 +137,7 @@
 	</div>
 
 	<div id="view">
-		<form id="search-bar" on:submit|preventDefault={search}>
+		<form id="search-bar" on:submit|preventDefault={searchAndResetPage}>
 			<Search
 				size="lg"
 				type="text"

--- a/frontend/src/routes/Search.svelte
+++ b/frontend/src/routes/Search.svelte
@@ -86,8 +86,7 @@
 								outline
 								on:click={async () => {
 									speciesFilter = s;
-                                    page = 0;
-									await search();
+                                    await searchAndResetPage();
 								}}
 							>
 								{s}
@@ -104,8 +103,7 @@
 						max={lengthExtent.max}
 						on:change={async ({ detail }) => {
 							lengthFilter = detail;
-                            page = 0;
-							await search();
+                            await searchAndResetPage();
 						}}
 					/>
 				{/if}
@@ -119,8 +117,7 @@
 						max={massExtent.max}
 						on:change={async ({ detail }) => {
 							massFilter = detail;
-                            page = 0;
-							await search();
+                            await searchAndResetPage()
 						}}
 					/>
 				{/if}
@@ -170,7 +167,12 @@
 				textRight
 			/>
         {:else if proteinEntries.length === 0}
-            No proteins found
+            { #if page > 0 }
+                No more proteins found
+            {:else}
+                No proteins found
+            {/if}
+            
 		{:else}
 			<ListProteins allEntries={proteinEntries} />
 		{/if}

--- a/frontend/src/routes/Search.svelte
+++ b/frontend/src/routes/Search.svelte
@@ -143,7 +143,7 @@
 			/>
 			<Button type="submit" size="sm">Search</Button>
 		</form>
-		{#if totalFound > 0}
+		{#if totalFound > 0 || page > 0}
 			<div id="found">
                 {#if totalFound == 1}
                     {totalFound} protein shown |

--- a/frontend/src/routes/Search.svelte
+++ b/frontend/src/routes/Search.svelte
@@ -150,7 +150,6 @@
                 {:else}
                     {totalFound} proteins shown |
                 {/if}
-				
                 <Button disabled={page <= 0} on:click={async()=>{
                     page--
                     await search();

--- a/frontend/src/routes/Search.svelte
+++ b/frontend/src/routes/Search.svelte
@@ -18,6 +18,7 @@
 	let lengthExtent: { min: number; max: number };
 	let massFilter: { min: number; max: number } | undefined;
 	let massExtent: { min: number; max: number };
+    let filterResetCounter = 0;
 
     let urlParams = new URLSearchParams(window.location.search)
     let proteinsPerPage = 20 // The number of proteins to show per page
@@ -63,6 +64,7 @@
 		massFilter = massExtent;
 		query = "";
         page = 0;
+        filterResetCounter++; // Incrementing this so relevant components can be destroyed and re-created
 		await search();
 	}
 </script>
@@ -98,28 +100,32 @@
 			<div>
 				<h3>Amino Acids Length</h3>
 				{#if lengthExtent && lengthFilter}
-					<RangerFilter
-						min={lengthExtent.min}
-						max={lengthExtent.max}
-						on:change={async ({ detail }) => {
-							lengthFilter = detail;
-                            await searchAndResetPage();
-						}}
-					/>
+                    {#key filterResetCounter}
+                        <RangerFilter
+                            min={lengthExtent.min}
+                            max={lengthExtent.max}
+                            on:change={async ({ detail }) => {
+                                lengthFilter = detail;
+                                await searchAndResetPage();
+                            }}
+                        />
+                    {/key}
 				{/if}
 			</div>
 
 			<div>
 				<h3>Mass (Da)</h3>
 				{#if massExtent && massFilter}
-					<RangerFilter
-						min={massExtent.min}
-						max={massExtent.max}
-						on:change={async ({ detail }) => {
-							massFilter = detail;
-                            await searchAndResetPage()
-						}}
-					/>
+                    {#key filterResetCounter}
+                        <RangerFilter
+                            min={massExtent.min}
+                            max={massExtent.max}
+                            on:change={async ({ detail }) => {
+                                massFilter = detail;
+                                await searchAndResetPage()
+                            }}
+                        />
+                    {/key}
 				{/if}
 			</div>
 


### PR DESCRIPTION
## Features
### Pages added to protein search
- Added two new optional JSON fields to POST search/proteins:
  - proteinsPerPage determines how many proteins come in the request.
  - page determines the offset. Note that this is 0-indexed.
  - If proteinsPerPage isn't given, the API call returns everything.
- Updated the front end search functionality to adhere to the above
- Added Previous Page" and "Next Page" buttons to the top right for the user to navigate to different pages.
  - Previous Page button is disabled if the page is 0
  - Next Page button is disabled in the number of returned elements is less than 20
  - Edge case: If the last page has exactly 20 proteins, pressing next page shows "No more proteins found"
- Changing any of the other search fields (including the search bar) resets the page to 0.
  - The function that does this is _searchAndResetPage()_

### Other Bug Fixes
- Fixed an issue where search returning 0 proteins would display spinner forever. Now it displays a "no proteins found" message.
- Fixed an issue where resetting filter did not visually reset the input fields

Closes #241 

## Demos
### Paging for entire database
What paging looks like when no search options are applied.

https://github.com/xnought/venome/assets/45224464/130e314f-d08e-4001-be34-8fb648c75f85

### Page interaction with other search features.
How paging interacts with the various search features. Shows what happens if the user has 0 proteins founds (page buttons hidden, message displayed) and what happens when the user encounters the last-page-20 edge case above (page buttons shown, different message displayed).

https://github.com/xnought/venome/assets/45224464/1cd101f7-8878-40fe-b791-87143e530be1


