### PR TITLE
feat: infinite scroll on protein search page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
 		"d3": "^7.9.0",
 		"js-cookie": "^3.0.5",
 		"marked": "^12.0.0",
+		"svelte-infinite-loading": "^1.3.8",
 		"svelte-routing": "^2.11.0"
 	},
 	"workspaces": [

--- a/frontend/src/lib/ListProteins.svelte
+++ b/frontend/src/lib/ListProteins.svelte
@@ -99,7 +99,6 @@
 		flex-wrap: wrap;
 		padding: 10px;
 		margin-left: 10px;
-		height: calc(100vh - 100px);
 	}
 	.prot-info {
 		width: 300px;

--- a/frontend/src/routes/Search.svelte
+++ b/frontend/src/routes/Search.svelte
@@ -19,7 +19,7 @@
 	let massFilter: { min: number; max: number } | undefined;
 	let massExtent: { min: number; max: number };
 	let filterResetCounter = 0;
-
+	let searchTop: HTMLFormElement;
 	let proteinsPerPage = 20; // The number of proteins to show per page
 	let page = 0;
 	onMount(async () => {
@@ -67,10 +67,12 @@
 		totalFound = result.totalFound;
 	}
 	async function searchAndResetPage() {
+		scrollTop();
 		page = 0;
 		await search();
 	}
 	async function resetFilter() {
+		scrollTop();
 		speciesFilter = undefined;
 		lengthFilter = lengthExtent;
 		massFilter = massExtent;
@@ -78,6 +80,10 @@
 		page = 0;
 		filterResetCounter++; // Incrementing this so relevant components can be destroyed and re-created
 		await search();
+	}
+
+	function scrollTop() {
+		searchTop.scrollIntoView({ block: "end" });
 	}
 </script>
 
@@ -142,8 +148,13 @@
 			</div>
 
 			<div class="mt-5">
-				<Button on:click={resetFilter} outline size="xs" color="light"
-					>Reset All Filters</Button
+				<Button
+					on:click={async () => {
+						await resetFilter();
+					}}
+					outline
+					size="xs"
+					color="light">Reset All Filters</Button
 				>
 			</div>
 		{:else}
@@ -152,7 +163,11 @@
 	</div>
 
 	<div id="view">
-		<form id="search-bar" on:submit|preventDefault={searchAndResetPage}>
+		<form
+			id="search-bar"
+			on:submit|preventDefault={searchAndResetPage}
+			bind:this={searchTop}
+		>
 			<div style="width: 500px;">
 				<Search
 					size="lg"
@@ -178,7 +193,9 @@
 			{/if}
 		{:else}
 			<ListProteins allEntries={proteinEntries} />
-			<InfiniteLoading on:infinite={infiniteProteinScroll} />
+			{#if totalFound !== 0}
+				<InfiniteLoading on:infinite={infiniteProteinScroll} />
+			{/if}
 		{/if}
 	</div>
 </section>

--- a/frontend/src/routes/Search.svelte
+++ b/frontend/src/routes/Search.svelte
@@ -129,38 +129,18 @@
 
 	<div id="view">
 		<form id="search-bar" on:submit|preventDefault={searchAndResetPage}>
-			<Search
-				size="lg"
-				type="text"
-				class="flex gap-2 items-center"
-				placeholder="Enter search..."
-				bind:value={query}
-			/>
-			<Button type="submit" size="sm">Search</Button>
-		</form>
-		{#if totalFound > 0 || page > 0}
-			<div id="found">
-				{#if totalFound == 1}
-					{totalFound} protein shown |
-				{:else}
-					{totalFound} proteins shown |
-				{/if}
-				<Button
-					disabled={page <= 0}
-					on:click={async () => {
-						page--;
-						await search();
-					}}>Previous {proteinsPerPage}</Button
-				> |
-				<Button
-					disabled={totalFound < proteinsPerPage}
-					on:click={async () => {
-						page++;
-						await search();
-					}}>Next {proteinsPerPage}</Button
-				>
+			<div style="width: 500px;">
+				<Search
+					size="lg"
+					type="text"
+					class="flex gap-2 items-center"
+					bind:value={query}
+				></Search>
 			</div>
-		{/if}
+			<div>
+				<Button type="submit">Search Proteins</Button>
+			</div>
+		</form>
 		{#if proteinEntries === undefined}
 			<DelayedSpinner
 				text="Fetching Proteins from the Venome DB..."
@@ -174,6 +154,26 @@
 			{/if}
 		{:else}
 			<ListProteins allEntries={proteinEntries} />
+			<div class="m-2">
+				<Button
+					color="light"
+					class="w-full"
+					on:click={async () => {
+						page++;
+						const result = await Backend.searchProteins({
+							query,
+							speciesFilter,
+							lengthFilter,
+							massFilter,
+							proteinsPerPage,
+							page,
+						});
+						proteinEntries = proteinEntries.concat(
+							result.proteinEntries
+						);
+					}}>Show More</Button
+				>
+			</div>
 		{/if}
 	</div>
 </section>
@@ -200,16 +200,16 @@
 
 	#search-bar {
 		display: flex;
-		width: 500px;
 		gap: 5px;
 		padding: 10px;
+		align-items: center;
 	}
 
 	#found {
 		position: absolute;
 		top: 25px;
 		right: 25px;
-		color: var(--primary-500);
+		color: var(--primary-700);
 	}
 	h3 {
 		margin-bottom: 3px;

--- a/frontend/src/routes/Search.svelte
+++ b/frontend/src/routes/Search.svelte
@@ -6,8 +6,6 @@
 	import { Search, Button } from "flowbite-svelte";
 	import RangerFilter from "../lib/RangerFilter.svelte";
 	import DelayedSpinner from "../lib/DelayedSpinner.svelte";
-	import app from "../main";
-	import { navigate } from "svelte-routing";
 
 	let query = "";
 	let proteinEntries: ProteinEntry[];

--- a/frontend/src/routes/Search.svelte
+++ b/frontend/src/routes/Search.svelte
@@ -6,8 +6,8 @@
 	import { Search, Button } from "flowbite-svelte";
 	import RangerFilter from "../lib/RangerFilter.svelte";
 	import DelayedSpinner from "../lib/DelayedSpinner.svelte";
-    import app from "../main";
-    import { navigate } from "svelte-routing";
+	import app from "../main";
+	import { navigate } from "svelte-routing";
 
 	let query = "";
 	let proteinEntries: ProteinEntry[];
@@ -18,28 +18,18 @@
 	let lengthExtent: { min: number; max: number };
 	let massFilter: { min: number; max: number } | undefined;
 	let massExtent: { min: number; max: number };
-    let filterResetCounter = 0;
+	let filterResetCounter = 0;
 
-    let urlParams = new URLSearchParams(window.location.search)
-    let proteinsPerPage = 20 // The number of proteins to show per page
-    let page = 0
+	let proteinsPerPage = 20; // The number of proteins to show per page
+	let page = 0;
 	onMount(async () => {
-        // Redirects user to ?page=1 if page query string not present
-
-        /*
-        if (page == null) {
-            navigate('search?page=1')
-        }
-        console.log("Page is", page)
-        */
-
 		await search();
 		species = await Backend.searchSpecies();
 		lengthExtent = await Backend.searchRangeLength();
 		massExtent = await Backend.searchRangeMass();
 		massFilter = massExtent;
 		lengthFilter = lengthExtent;
-        console.log(page)
+		console.log(page);
 	});
 
 	async function search() {
@@ -48,23 +38,23 @@
 			speciesFilter,
 			lengthFilter,
 			massFilter,
-            proteinsPerPage,
-            page
+			proteinsPerPage,
+			page,
 		});
 		proteinEntries = result.proteinEntries;
 		totalFound = result.totalFound;
 	}
-    async function searchAndResetPage() {
-        page = 0;
-        await search();
-    }
+	async function searchAndResetPage() {
+		page = 0;
+		await search();
+	}
 	async function resetFilter() {
 		speciesFilter = undefined;
 		lengthFilter = lengthExtent;
 		massFilter = massExtent;
 		query = "";
-        page = 0;
-        filterResetCounter++; // Incrementing this so relevant components can be destroyed and re-created
+		page = 0;
+		filterResetCounter++; // Incrementing this so relevant components can be destroyed and re-created
 		await search();
 	}
 </script>
@@ -88,7 +78,7 @@
 								outline
 								on:click={async () => {
 									speciesFilter = s;
-                                    await searchAndResetPage();
+									await searchAndResetPage();
 								}}
 							>
 								{s}
@@ -100,32 +90,32 @@
 			<div>
 				<h3>Amino Acids Length</h3>
 				{#if lengthExtent && lengthFilter}
-                    {#key filterResetCounter}
-                        <RangerFilter
-                            min={lengthExtent.min}
-                            max={lengthExtent.max}
-                            on:change={async ({ detail }) => {
-                                lengthFilter = detail;
-                                await searchAndResetPage();
-                            }}
-                        />
-                    {/key}
+					{#key filterResetCounter}
+						<RangerFilter
+							min={lengthExtent.min}
+							max={lengthExtent.max}
+							on:change={async ({ detail }) => {
+								lengthFilter = detail;
+								await searchAndResetPage();
+							}}
+						/>
+					{/key}
 				{/if}
 			</div>
 
 			<div>
 				<h3>Mass (Da)</h3>
 				{#if massExtent && massFilter}
-                    {#key filterResetCounter}
-                        <RangerFilter
-                            min={massExtent.min}
-                            max={massExtent.max}
-                            on:change={async ({ detail }) => {
-                                massFilter = detail;
-                                await searchAndResetPage()
-                            }}
-                        />
-                    {/key}
+					{#key filterResetCounter}
+						<RangerFilter
+							min={massExtent.min}
+							max={massExtent.max}
+							on:change={async ({ detail }) => {
+								massFilter = detail;
+								await searchAndResetPage();
+							}}
+						/>
+					{/key}
 				{/if}
 			</div>
 
@@ -152,19 +142,25 @@
 		</form>
 		{#if totalFound > 0 || page > 0}
 			<div id="found">
-                {#if totalFound == 1}
-                    {totalFound} protein shown |
-                {:else}
-                    {totalFound} proteins shown |
-                {/if}
-                <Button disabled={page <= 0} on:click={async()=>{
-                    page--
-                    await search();
-                }}>Previous {proteinsPerPage}</Button> | 
-                <Button disabled={totalFound < proteinsPerPage} on:click={async()=>{
-                    page++
-                    await search();
-                }}>Next {proteinsPerPage}</Button>
+				{#if totalFound == 1}
+					{totalFound} protein shown |
+				{:else}
+					{totalFound} proteins shown |
+				{/if}
+				<Button
+					disabled={page <= 0}
+					on:click={async () => {
+						page--;
+						await search();
+					}}>Previous {proteinsPerPage}</Button
+				> |
+				<Button
+					disabled={totalFound < proteinsPerPage}
+					on:click={async () => {
+						page++;
+						await search();
+					}}>Next {proteinsPerPage}</Button
+				>
 			</div>
 		{/if}
 		{#if proteinEntries === undefined}
@@ -172,13 +168,12 @@
 				text="Fetching Proteins from the Venome DB..."
 				textRight
 			/>
-        {:else if proteinEntries.length === 0}
-            { #if page > 0 }
-                No more proteins found
-            {:else}
-                No proteins found
-            {/if}
-            
+		{:else if proteinEntries.length === 0}
+			{#if page > 0}
+				No more proteins found
+			{:else}
+				No proteins found
+			{/if}
 		{:else}
 			<ListProteins allEntries={proteinEntries} />
 		{/if}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7235,6 +7235,11 @@ svelte-hmr@^0.15.3:
   resolved "https://registry.yarnpkg.com/svelte-hmr/-/svelte-hmr-0.15.3.tgz#df54ccde9be3f091bf5f18fc4ef7b8eb6405fbe6"
   integrity sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==
 
+svelte-infinite-loading@^1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/svelte-infinite-loading/-/svelte-infinite-loading-1.3.8.tgz#c479938bd5ca69264fe591ffbbb013b368afe578"
+  integrity sha512-hn4o848LKd2Q+M11hiMWnfFxM1GHKVDi92HPZ1FYvfed4bEeRZL+QvFAQzhy1SACq6Si0CAJcQFUZpIYmAEnpQ==
+
 svelte-preprocess@^5.1.0:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-5.1.3.tgz#7682239fe53f724c845b53026816fdfe15d028f9"


### PR DESCRIPTION
Instead of restyling the pagination, I opted to do infinite scroll instead.

When user scrolls down far enough, requests next page of proteins to simulate infinite scroll.

I added a new package so make sure to `./run.sh refresh_packages`.


https://github.com/xnought/venome/assets/65095341/03326737-f590-47d5-ad47-49d4c11c36c3




closes #250 